### PR TITLE
调整二维展开图

### DIFF
--- a/CNCBend_3D.pro.user
+++ b/CNCBend_3D.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 3.0.0, 2017-05-04T08:56:16. -->
+<!-- Written by QtCreator 3.0.0, 2017-05-15T18:25:35. -->
 <qtcreator>
  <data>
   <variable>ProjectExplorer.Project.ActiveTarget</variable>

--- a/bendglwidget.cpp
+++ b/bendglwidget.cpp
@@ -164,100 +164,146 @@ void bendGLWidget::setShowModel(fileOperate *pData)
         normalVector.z = backCenter.z - frontCeneter.z;
         qDebug()<<"法向量坐标：X"<<normalVector.x<<"  Y"<<normalVector.y<<"  Z"<<normalVector.z;
         /*****************************根据求得的法向量来变换钣金件，使得平行于地面**********************/
-        if(normalVector.z > 0.5)
+        if(0==normalVector.x && normalVector.y>0 && 0==normalVector.z )
         {
-            //绕X轴旋转-90度
-            xform_type rotateMatrix;
-            rotateMatrix.R11 = 1;
-            rotateMatrix.R12 = 0;
-            rotateMatrix.R13 = 0;
-            rotateMatrix.R21 = 0;
-            rotateMatrix.R22 = 0;
-            rotateMatrix.R23 = 1;
-            rotateMatrix.R31 = 0;
-            rotateMatrix.R32 = -1;
-            rotateMatrix.R33 = 0;
-            rotateMatrix.T1 = 0;
-            rotateMatrix.T2 = 0;
-            rotateMatrix.T3 = 0;
-            pDrawData->adjustWorkpiece(rotateMatrix,true);
+
         }
-        else if(normalVector.z < -0.5)
+        else if(normalVector.x!=0 || normalVector.y!=0 || normalVector.z!=0)
         {
-            //绕x轴旋转90度
-            xform_type rotateMatrix;
-            rotateMatrix.R11 = 1;
-            rotateMatrix.R12 = 0;
-            rotateMatrix.R13 = 0;
-            rotateMatrix.R21 = 0;
-            rotateMatrix.R22 = 0;
-            rotateMatrix.R23 = -1;
-            rotateMatrix.R31 = 0;
-            rotateMatrix.R32 = 1;
-            rotateMatrix.R33 = 0;
-            rotateMatrix.T1 = 0;
-            rotateMatrix.T2 = 0;
-            rotateMatrix.T3 = 0;
-            pDrawData->adjustWorkpiece(rotateMatrix,true);
+            /*先求绕X轴旋转的角度和矩阵*/
+            float RotateXangle = 0 - atan2(normalVector.z,normalVector.y);
+            qDebug()<<"绕X轴旋转的角度：X"<<RotateXangle*180/M_PI;
+            xform_type rotate_X_Matrix;
+            rotate_X_Matrix.R11 = 1;
+            rotate_X_Matrix.R12 = 0;
+            rotate_X_Matrix.R13 = 0;
+            rotate_X_Matrix.R21 = 0;
+            rotate_X_Matrix.R22 = cos(RotateXangle);
+            rotate_X_Matrix.R23 = -sin(RotateXangle);
+            rotate_X_Matrix.R31 = 0;
+            rotate_X_Matrix.R32 = sin(RotateXangle);
+            rotate_X_Matrix.R33 = cos(RotateXangle);
+            rotate_X_Matrix.T1 = 0;
+            rotate_X_Matrix.T2 = 0;
+            rotate_X_Matrix.T3 = 0;
+            pDrawData->adjustWorkpiece(rotate_X_Matrix,true);
+
+            /*再求绕Z轴旋转的角度和矩阵*/
+            float length = sqrt(normalVector.y*normalVector.y+normalVector.z*normalVector.z);
+            if(normalVector.y<0)
+                length = -length;
+            float RotateZangle = atan2(normalVector.x,length);
+            qDebug()<<"绕Z轴旋转的角度：Z"<<RotateZangle*180/M_PI;
+            xform_type rotate_Z_Matrix;
+            rotate_Z_Matrix.R11 = cos(RotateZangle);
+            rotate_Z_Matrix.R12 = -sin(RotateZangle);
+            rotate_Z_Matrix.R13 = 0;
+            rotate_Z_Matrix.R21 = sin(RotateZangle);
+            rotate_Z_Matrix.R22 = cos(RotateZangle);
+            rotate_Z_Matrix.R23 = 0;
+            rotate_Z_Matrix.R31 = 0;
+            rotate_Z_Matrix.R32 = 0;
+            rotate_Z_Matrix.R33 = 1;
+            rotate_Z_Matrix.T1 = 0;
+            rotate_Z_Matrix.T2 = 0;
+            rotate_Z_Matrix.T3 = 0;
+            pDrawData->adjustWorkpiece(rotate_Z_Matrix,true);
         }
-        else if(normalVector.x > 0.5)
-        {
-            //绕z轴旋转90度
-            xform_type rotateMatrix;
-            rotateMatrix.R11 = 0;
-            rotateMatrix.R12 = -1;
-            rotateMatrix.R13 = 0;
-            rotateMatrix.R21 = 1;
-            rotateMatrix.R22 = 0;
-            rotateMatrix.R23 = 0;
-            rotateMatrix.R31 = 0;
-            rotateMatrix.R32 = 0;
-            rotateMatrix.R33 = 1;
-            rotateMatrix.T1 = 0;
-            rotateMatrix.T2 = 0;
-            rotateMatrix.T3 = 0;
-            pDrawData->adjustWorkpiece(rotateMatrix,true);
-        }
-        else if(normalVector.x < -0.5)
-        {
-            //绕z轴旋转-90度
-            xform_type rotateMatrix;
-            rotateMatrix.R11 = 0;
-            rotateMatrix.R12 = 1;
-            rotateMatrix.R13 = 0;
-            rotateMatrix.R21 = -1;
-            rotateMatrix.R22 = 0;
-            rotateMatrix.R23 = 0;
-            rotateMatrix.R31 = 0;
-            rotateMatrix.R32 = 0;
-            rotateMatrix.R33 = 1;
-            rotateMatrix.T1 = 0;
-            rotateMatrix.T2 = 0;
-            rotateMatrix.T3 = 0;
-            pDrawData->adjustWorkpiece(rotateMatrix,true);
-        }
-        else if(normalVector.y < -0.5)
-        {
-            //绕x轴旋转180度
-            xform_type rotateMatrix;
-            rotateMatrix.R11 = 1;
-            rotateMatrix.R12 = 0;
-            rotateMatrix.R13 = 0;
-            rotateMatrix.R21 = 0;
-            rotateMatrix.R22 = -1;
-            rotateMatrix.R23 = 0;
-            rotateMatrix.R31 = 0;
-            rotateMatrix.R32 = 0;
-            rotateMatrix.R33 = -1;
-            rotateMatrix.T1 = 0;
-            rotateMatrix.T2 = 0;
-            rotateMatrix.T3 = 0;
-            pDrawData->adjustWorkpiece(rotateMatrix,true);
-        }
-        else if(normalVector.y > 0.5)
-        {
-            //是想要的姿态，do nothing
-        }
+
+//         if(normalVector.z > 0.5)
+//        {
+//            //绕X轴旋转-90度
+//            xform_type rotateMatrix;
+//            rotateMatrix.R11 = 1;
+//            rotateMatrix.R12 = 0;
+//            rotateMatrix.R13 = 0;
+//            rotateMatrix.R21 = 0;
+//            rotateMatrix.R22 = 0;
+//            rotateMatrix.R23 = 1;
+//            rotateMatrix.R31 = 0;
+//            rotateMatrix.R32 = -1;
+//            rotateMatrix.R33 = 0;
+//            rotateMatrix.T1 = 0;
+//            rotateMatrix.T2 = 0;
+//            rotateMatrix.T3 = 0;
+//            pDrawData->adjustWorkpiece(rotateMatrix,true);
+//        }
+//        else if(normalVector.z < -0.5)
+//        {
+//            //绕x轴旋转90度
+//            xform_type rotateMatrix;
+//            rotateMatrix.R11 = 1;
+//            rotateMatrix.R12 = 0;
+//            rotateMatrix.R13 = 0;
+//            rotateMatrix.R21 = 0;
+//            rotateMatrix.R22 = 0;
+//            rotateMatrix.R23 = -1;
+//            rotateMatrix.R31 = 0;
+//            rotateMatrix.R32 = 1;
+//            rotateMatrix.R33 = 0;
+//            rotateMatrix.T1 = 0;
+//            rotateMatrix.T2 = 0;
+//            rotateMatrix.T3 = 0;
+//            pDrawData->adjustWorkpiece(rotateMatrix,true);
+//        }
+//        else if(normalVector.x > 0.5)
+//        {
+//            //绕z轴旋转90度
+//            xform_type rotateMatrix;
+//            rotateMatrix.R11 = 0;
+//            rotateMatrix.R12 = -1;
+//            rotateMatrix.R13 = 0;
+//            rotateMatrix.R21 = 1;
+//            rotateMatrix.R22 = 0;
+//            rotateMatrix.R23 = 0;
+//            rotateMatrix.R31 = 0;
+//            rotateMatrix.R32 = 0;
+//            rotateMatrix.R33 = 1;
+//            rotateMatrix.T1 = 0;
+//            rotateMatrix.T2 = 0;
+//            rotateMatrix.T3 = 0;
+//            pDrawData->adjustWorkpiece(rotateMatrix,true);
+//        }
+//        else if(normalVector.x < -0.5)
+//        {
+//            //绕z轴旋转-90度
+//            xform_type rotateMatrix;
+//            rotateMatrix.R11 = 0;
+//            rotateMatrix.R12 = 1;
+//            rotateMatrix.R13 = 0;
+//            rotateMatrix.R21 = -1;
+//            rotateMatrix.R22 = 0;
+//            rotateMatrix.R23 = 0;
+//            rotateMatrix.R31 = 0;
+//            rotateMatrix.R32 = 0;
+//            rotateMatrix.R33 = 1;
+//            rotateMatrix.T1 = 0;
+//            rotateMatrix.T2 = 0;
+//            rotateMatrix.T3 = 0;
+//            pDrawData->adjustWorkpiece(rotateMatrix,true);
+//        }
+//        else if(normalVector.y < -0.5)
+//        {
+//            //绕x轴旋转180度
+//            xform_type rotateMatrix;
+//            rotateMatrix.R11 = 1;
+//            rotateMatrix.R12 = 0;
+//            rotateMatrix.R13 = 0;
+//            rotateMatrix.R21 = 0;
+//            rotateMatrix.R22 = -1;
+//            rotateMatrix.R23 = 0;
+//            rotateMatrix.R31 = 0;
+//            rotateMatrix.R32 = 0;
+//            rotateMatrix.R33 = -1;
+//            rotateMatrix.T1 = 0;
+//            rotateMatrix.T2 = 0;
+//            rotateMatrix.T3 = 0;
+//            pDrawData->adjustWorkpiece(rotateMatrix,true);
+//        }
+//        else if(normalVector.y > 0.5)
+//        {
+//            //是想要的姿态，do nothing
+//        }
         isFirstLoad = false;
     }
     updateGL();

--- a/bendglwidget.h
+++ b/bendglwidget.h
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "fileoperate.h"
+#include<math.h>
 
 #define ACCURACY_NUM    50
 #define MAX_SIZE        4096

--- a/filereader.cpp
+++ b/filereader.cpp
@@ -1765,8 +1765,8 @@ void fileReader::getThickAndRadiusAndAngle(bend_surface *pHead)
             workpiece_thickness = thickness;
             pbend->bendRadius = min_radius;
             pbend->pParallel->bendRadius = min_radius;
-            pbend->bendAngle = angle;
-            pbend->pParallel->bendAngle = angle;
+            pbend->bendAngle = -angle;
+            pbend->pParallel->bendAngle = -angle;
         }
         else
         {
@@ -1774,8 +1774,8 @@ void fileReader::getThickAndRadiusAndAngle(bend_surface *pHead)
             workpiece_thickness = thickness;
             pbend->bendRadius = max_radius;
             pbend->pParallel->bendRadius = max_radius;
-            pbend->bendAngle = -angle;
-            pbend->pParallel->bendAngle = -angle;
+            pbend->bendAngle = angle;
+            pbend->pParallel->bendAngle = angle;
         }
         pbend = pbend->pNext;
     }

--- a/uideploypage.cpp
+++ b/uideploypage.cpp
@@ -106,7 +106,7 @@ void uiDeployPage::paintEvent(QPaintEvent *e)
     e = e;
     iWidth = e->rect().width();
     iHeight = e->rect().height();
-    zoom = 200.0/iWidth + 400.0/iHeight;
+    zoom = 200.0/iWidth + 600.0/iHeight;
     QPainter painter(this);
     if(maxLength<100)
     {

--- a/uideploypage.h.autosave
+++ b/uideploypage.h.autosave
@@ -30,7 +30,7 @@ private:
     bend_surface *pBendHead;
     bend_order *pOrderHead;
     float maxLength;
-    float K ; //二维展开图的缩放比例
+    float K ; //根据钣金基面最大长度确定二维展开图的缩放比例K
 
     float xRote,yRote,zRote;
     float zoom,vMove,hMove;


### PR DESCRIPTION
当导入的钣金件尺寸过小时，根据钣金件基面的最大边长来调整二维展开图的缩放比例